### PR TITLE
Updated to work with Redmine 1.3.0

### DIFF
--- a/app/controllers/issues_export_controller.rb
+++ b/app/controllers/issues_export_controller.rb
@@ -38,7 +38,7 @@ class IssuesExportController < ApplicationController
                               :order => sort_clause, 
                               :offset => @offset, 
                               :limit => @limit)
-      csv = issues_to_csv(@issues, @project)
+      csv = issues_to_csv(@issues, @project, @query)
       send_data(add_journals(csv), :filename => 'export.csv', :type => 'text/csv')
     end
   end


### PR DESCRIPTION
The plugin didn't work with 1.3.0 because the arguments to issues_to_csv() were changed to include the query object.
