### PR TITLE
Use String#encode instead of Iconv

### DIFF
--- a/app/helpers/issues_export_helper.rb
+++ b/app/helpers/issues_export_helper.rb
@@ -1,7 +1,7 @@
 module IssuesExportHelper
   def add_journals(csv)
     csv_with_journals = FCSV.generate do |newcsv|
-      FCSV.parse(Iconv.conv('UTF-8', 'Shift_JIS', csv), :headers => true, :return_headers => true) do |row|
+      FCSV.parse(csv.encode('UTF-8', 'Shift_JIS'), :headers => true, :return_headers => true) do |row|
         if row.header_row?
           newcsv << row.fields + [t(:label_history)]
         else
@@ -11,6 +11,6 @@ module IssuesExportHelper
         end
       end
     end
-    Iconv.conv('Shift_JIS', 'UTF-8', csv_with_journals)
+    csv_with_journals.encode('Shift_JIS', 'UTF-8', :undef => :replace)
   end
 end


### PR DESCRIPTION
便利なプラグインありがとうございます。
### 変更点
- Iconv から String#encode を使って変換するようにしました
### 動作確認環境

Redmine 2.1.0 on CentOS 6.3
### 動機
- UTF-8 から Shift_JIS に変換する際に Shift_JIS に存在しない文字がある場合エラーになり CSV 出力が出来ないケースがありました。
- `Iconv.conv('Shitf_JIS//IGNORE', 'UTF-8', string)` でも同等な効果が得られましたが「GNU libiconv で iconv ライブラリがビルドしてある場合に使えるという環境依存」のためString#encode を採用しました ([library iconv](http://doc.ruby-lang.org/ja/1.9.3/library/iconv.html))
