### PR TITLE
Add English translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,3 @@
 # English strings go here for Rails i18n
 en:
-  my_label: "My label"
+  label_export_with_journals: "CSV export (including history)"


### PR DESCRIPTION
I have translated label_export_with_journals to English.

Without English translation, users whose language setting is other than Japanese will see "translation missing: #{language}.label_export_with_journals" instead of a proper label.

<img width="332" alt="image" src="https://user-images.githubusercontent.com/114863/66020808-5a1d5a80-e523-11e9-847f-d01e593637f5.png">
