### PR TITLE
Fix that buttons are disabled after export

### DIFF
--- a/app/views/hooks/export_with_journals/_view_issues_index_bottom.html.erb
+++ b/app/views/hooks/export_with_journals/_view_issues_index_bottom.html.erb
@@ -19,8 +19,8 @@
     <label><%= check_box_tag 'c[]', 'last_notes', @query.has_column?(:last_notes) %> <%= l(:label_last_notes) %></label>
   </p>
   <p class="buttons">
-    <%= submit_tag l(:button_export), :name => nil, :onclick => "hideModal(this);" %>
-    <%= submit_tag l(:button_cancel), :name => nil, :onclick => "hideModal(this);", :type => 'button' %>
+    <%= submit_tag l(:button_export), :name => nil, :onclick => "hideModal(this);", :data => { :disable_with => false } %>
+    <%= submit_tag l(:button_cancel), :name => nil, :onclick => "hideModal(this);", :type => 'button', :data => { :disable_with => false } %>
   </p>
   <% end %>
 </div>


### PR DESCRIPTION
Buttons are disabled after exporting issues.

Steps to reproduce:
1. Click the export link
2. Export issues
3. Click the export link again
4. You will see disabled buttons

![Screenshot_2019-10-02 Issues - eCookbook - Redmine](https://user-images.githubusercontent.com/114863/66031521-8c888100-e53e-11e9-9634-bc2606e33944.png)

Related to: https://www.redmine.org/issues/28482