### PR TITLE
Remove undefined method 'unloadable'

### DIFF
--- a/app/controllers/issues_export_controller.rb
+++ b/app/controllers/issues_export_controller.rb
@@ -1,5 +1,4 @@
 class IssuesExportController < ApplicationController
-  unloadable
   include IssuesHelper
   include IssuesExportHelper
   helper :journals


### PR DESCRIPTION
Redmine trunk ([r22862](https://www.redmine.org/projects/redmine/repository/svn/revisions/22862
)) builds on rails 7.1.2, but when I install this plugin it crashes with an undefined method error.

```
Default configuration data loaded.
=> Booting Puma
=> Rails 7.1.2 application starting in production 
=> Run `bin/rails server --help` for more startup options
Exiting
/tmp/redmine/plugins/redmine_export_with_journals/app/controllers/issues_export_controller.rb:2:in `<class:IssuesExportController>': undefined local variable or method `unloadable' for IssuesExportController:Class (NameError)

  unloadable
  ^^^^^^^^^^
    from /tmp/redmine/plugins/redmine_export_with_journals/app/controllers/issues_export_controller.rb:1:in `<top (required)>'
    from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
    from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
```

After some research, I found that the `unloadable` method was defined in Rails 6.1.7.7 and earlier, but is undefined in Rails 7 and later.
https://apidock.com/rails/v6.1.7.7/ActiveSupport/Dependencies/Loadable/unloadable