### PR TITLE
Improve DEPRECATION WARNING

### DIFF
--- a/app/controllers/issues_export_controller.rb
+++ b/app/controllers/issues_export_controller.rb
@@ -29,7 +29,7 @@ class IssuesExportController < ApplicationController
     if @query.valid?
       @issue_count = @query.issue_count
       @limit = Setting.issues_export_limit.to_i
-      @issue_pages = Paginator.new self, @issue_count, @limit, params['page']
+      @issue_pages = Paginator.new @issue_count, @limit, params['page']
       @offset ||= @issue_pages.current.offset
       @issues = @query.issues(:include => [:assigned_to, :tracker, :priority, :category, :fixed_version],
                               :order => sort_clause, 

--- a/app/controllers/issues_export_controller.rb
+++ b/app/controllers/issues_export_controller.rb
@@ -30,7 +30,7 @@ class IssuesExportController < ApplicationController
       @issue_count = @query.issue_count
       @limit = Setting.issues_export_limit.to_i
       @issue_pages = Paginator.new @issue_count, @limit, params['page']
-      @offset ||= @issue_pages.current.offset
+      @offset ||= @issue_pages.offset
       @issues = @query.issues(:include => [:assigned_to, :tracker, :priority, :category, :fixed_version],
                               :order => sort_clause, 
                               :offset => @offset, 


### PR DESCRIPTION
When you export CSV from the issue list, the following log is output.

```
Started GET "/projects/issues_export/export_with_journals?project_id=&set_filter=1&f%5B%5D=status_id&op%5Bstatus_id%5D=o&v%5Bstatus_id%5D%5B%5D=&c%5B%5D=id&c%5B%5D=project&c%5B%5D=tracker&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=subject&c%5B%5D=assigned_to&c%5B%5D=updated_on&sort=id%3Adesc&columns=&c%5B%5D=description&c%5B%5D=last_notes" for 192.168.65.1 at 2024-06-06 04:23:38 +0000
Processing by IssuesExportController#export_with_journals as HTML
  Parameters: {"project_id"=>"", "set_filter"=>"1", "f"=>["status_id"], "op"=>{"status_id"=>"o"}, "v"=>{"status_id"=>[""]}, "c"=>["id", "project", "tracker", "status", "priority", "subject", "assigned_to", "updated_on", "description", "last_notes"], "sort"=>"id:desc", "columns"=>""}
  Current user: admin (id=1)
DEPRECATION WARNING: Paginator no longer takes a controller instance as the first argument. Remove it from #new arguments. (called from new at /tmp/redmine/plugins/redmine_export_with_journals/app/controllers/issues_export_controller.rb:31)
DEPRECATION WARNING: Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use your own Deprecation object instead) (called from initialize at /tmp/redmine/lib/redmine/pagination.rb:28)
DEPRECATION WARNING: Paginator#current will be removed. Use .offset instead of .current.offset. (called from export_with_journals at /tmp/redmine/plugins/redmine_export_with_journals/app/controllers/issues_export_controller.rb:32)
DEPRECATION WARNING: Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use your own Deprecation object instead) (called from current at /tmp/redmine/lib/redmine/pagination.rb:103)
 Sent data export.csv (0.4ms)
 Completed 200 OK in 65ms (Views: 0.3ms | ActiveRecord: 5.4ms | Allocations: 20928)
```

I created a pull request to improve the DEPRECATION WARNING.

Ref. https://www.redmine.org/issues/12774